### PR TITLE
chore: release v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "librazer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/blade-helper/Cargo.toml
+++ b/blade-helper/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stvnksslr/razer-ctl"
 publish = false
 
 [dependencies]
-librazer = { path = "../librazer", version = "0.7.0" }
+librazer = { path = "../librazer", version = "0.7.1" }
 clap = { version = "4.5.1", features = ["derive", "cargo"] }
 anyhow = "1.0.80"
 thiserror = "1.0"

--- a/librazer/CHANGELOG.md
+++ b/librazer/CHANGELOG.md
@@ -6,3 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.1](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.0...librazer-v0.7.1) - 2025-12-26
+
+### Other
+- chore(cicd) (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr

--- a/librazer/Cargo.toml
+++ b/librazer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librazer"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Library for controlling Razer laptop BIOS settings via USB HID"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `librazer`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.0...librazer-v0.7.1) - 2025-12-26

### Other
- chore(cicd) (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).