### PR TITLE
chore: release v0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blade-helper"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -370,7 +370,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "librazer"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [ "librazer", "blade-helper"]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 
 [profile.release]
 lto = true

--- a/blade-helper/CHANGELOG.md
+++ b/blade-helper/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.3](https://github.com/stvnksslr/razer-ctl/compare/blade-helper-v0.7.2...blade-helper-v0.7.3) - 2025-12-27
+
+### Other
+- chore(cicd) (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.7.2](https://github.com/stvnksslr/razer-ctl/compare/blade-helper-v0.7.1...blade-helper-v0.7.2) - 2025-12-27
 
 ### Added

--- a/blade-helper/Cargo.toml
+++ b/blade-helper/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["razer", "blade", "laptop", "cli"]
 categories = ["command-line-utilities", "hardware-support"]
 
 [dependencies]
-librazer = { path = "../librazer", version = "0.7.2" }
+librazer = { path = "../librazer", version = "0.7.3" }
 clap = { version = "4.5.1", features = ["derive", "cargo"] }
 anyhow = "1.0.80"
 thiserror = "1.0"


### PR DESCRIPTION



## 🤖 New release

* `librazer`: 0.7.2 -> 0.7.3
* `blade-helper`: 0.7.2 -> 0.7.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `librazer`

<blockquote>

## [0.7.2](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.1...librazer-v0.7.2) - 2025-12-27

### Added
- feat(librazer readme): (by @stvnksslr)

### Fixed
- fix(permission issue + publish logic): (by @stvnksslr)

### Other
- chore(cicd) (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>

## `blade-helper`

<blockquote>

## [0.7.3](https://github.com/stvnksslr/razer-ctl/compare/blade-helper-v0.7.2...blade-helper-v0.7.3) - 2025-12-27

### Other
- chore(cicd) (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).