### PR TITLE
chore: release v0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bhelper"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -360,7 +360,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "librazer"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [ "librazer", "bhelper"]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 
 [profile.release]
 lto = true

--- a/bhelper/CHANGELOG.md
+++ b/bhelper/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/bhelper-v0.7.3...bhelper-v0.7.4) - 2025-12-27
+
+### Added
+- *(cicd + readme)* this should be the last of the code churn, got the build steps and tooling nailed down (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.7.3](https://github.com/stvnksslr/razer-ctl/compare/blade-helper-v0.7.2...blade-helper-v0.7.3) - 2025-12-27
 
 ### Other

--- a/bhelper/Cargo.toml
+++ b/bhelper/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["razer", "blade", "laptop", "cli"]
 categories = ["command-line-utilities", "hardware-support"]
 
 [dependencies]
-librazer = { path = "../librazer", version = "0.7.3" }
+librazer = { path = "../librazer", version = "0.7.4" }
 clap = { version = "4.5.1", features = ["derive", "cargo"] }
 anyhow = "1.0.80"
 thiserror = "1.0"

--- a/librazer/CHANGELOG.md
+++ b/librazer/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.3...librazer-v0.7.4) - 2025-12-27
+
+### Added
+- *(cicd + readme)* this should be the last of the code churn, got the build steps and tooling nailed down (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.7.2](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.1...librazer-v0.7.2) - 2025-12-27
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `librazer`: 0.7.3 -> 0.7.4 (✓ API compatible changes)
* `bhelper`: 0.7.3 -> 0.7.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `librazer`

<blockquote>

## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.3...librazer-v0.7.4) - 2025-12-27

### Added
- *(cicd + readme)* this should be the last of the code churn, got the build steps and tooling nailed down (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>

## `bhelper`

<blockquote>

## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/bhelper-v0.7.3...bhelper-v0.7.4) - 2025-12-27

### Added
- *(cicd + readme)* this should be the last of the code churn, got the build steps and tooling nailed down (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).