### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bhelper"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -340,7 +340,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "librazer"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [ "librazer", "bhelper"]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.8.0"
 
 [profile.release]
 lto = true

--- a/bhelper/Cargo.toml
+++ b/bhelper/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["razer", "blade", "laptop", "cli"]
 categories = ["command-line-utilities", "hardware-support"]
 
 [dependencies]
-librazer = { path = "../librazer", version = "0.7.4" }
+librazer = { path = "../librazer", version = "0.8.0" }
 clap = { version = "4.5.1", features = ["derive", "cargo"] }
 anyhow = "1.0.80"
 thiserror = "1.0"

--- a/librazer/CHANGELOG.md
+++ b/librazer/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.8.0](https://github.com/stvnksslr/razer-laptop-tools/compare/librazer-v0.7.4...librazer-v0.8.0) - 2025-12-27
+
+### Other
+- *(librazer)* code quality improvements (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/librazer-v0.7.3...librazer-v0.7.4) - 2025-12-27
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `librazer`: 0.7.4 -> 0.8.0 (⚠ API breaking changes)
* `bhelper`: 0.7.4 -> 0.8.0

### ⚠ `librazer` breaking changes

```text
--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A `macro_rules!` declarative macro cannot be invoked by its prior name. The macro may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro iter_features, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct librazer::feature::LightsAlwaysOn, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71
  struct librazer::feature::KbdBacklight, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71
  struct librazer::feature::Fan, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71
  struct librazer::feature::Perf, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71
  struct librazer::feature::BatteryCare, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71
  struct librazer::feature::LidLogo, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:71

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait librazer::feature::Feature, previously in file /tmp/.tmp9lDUnM/librazer/src/feature.rs:3
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `librazer`

<blockquote>

## [0.8.0](https://github.com/stvnksslr/razer-laptop-tools/compare/librazer-v0.7.4...librazer-v0.8.0) - 2025-12-27

### Other
- *(librazer)* code quality improvements (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>

## `bhelper`

<blockquote>

## [0.7.4](https://github.com/stvnksslr/razer-ctl/compare/bhelper-v0.7.3...bhelper-v0.7.4) - 2025-12-27

### Added
- *(cicd + readme)* this should be the last of the code churn, got the build steps and tooling nailed down (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).