### PR TITLE
chore: release v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bhelper"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -340,7 +340,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "librazer"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [ "librazer", "bhelper"]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 
 [profile.release]
 lto = true

--- a/bhelper/CHANGELOG.md
+++ b/bhelper/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.8.2](https://github.com/stvnksslr/razer-laptop-tools/compare/bhelper-v0.8.1...bhelper-v0.8.2) - 2025-12-27
+
+### Other
+- goreleaser fixes (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 
 ## [0.8.1](https://github.com/stvnksslr/razer-laptop-tools/compare/bhelper-v0.8.0...bhelper-v0.8.1) - 2025-12-27
 

--- a/bhelper/Cargo.toml
+++ b/bhelper/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["razer", "blade", "laptop", "cli"]
 categories = ["command-line-utilities", "hardware-support"]
 
 [dependencies]
-librazer = { path = "../librazer", version = "0.8.1" }
+librazer = { path = "../librazer", version = "0.8.2" }
 clap = { version = "4.5.1", features = ["derive", "cargo"] }
 anyhow = "1.0.80"
 thiserror = "1.0"

--- a/librazer/CHANGELOG.md
+++ b/librazer/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.8.2](https://github.com/stvnksslr/razer-laptop-tools/compare/librazer-v0.8.1...librazer-v0.8.2) - 2025-12-27
+
+### Other
+- goreleaser fixes (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 
 ## [0.8.1](https://github.com/stvnksslr/razer-laptop-tools/compare/librazer-v0.8.0...librazer-v0.8.1) - 2025-12-27
 


### PR DESCRIPTION



## 🤖 New release

* `librazer`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `bhelper`: 0.8.1 -> 0.8.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `librazer`

<blockquote>

## [0.8.2](https://github.com/stvnksslr/razer-laptop-tools/compare/librazer-v0.8.1...librazer-v0.8.2) - 2025-12-27

### Other
- goreleaser fixes (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>

## `bhelper`

<blockquote>

## [0.8.2](https://github.com/stvnksslr/razer-laptop-tools/compare/bhelper-v0.8.1...bhelper-v0.8.2) - 2025-12-27

### Other
- goreleaser fixes (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).